### PR TITLE
feat(utils): add more utils

### DIFF
--- a/src/kurisunet/utils/debug.py
+++ b/src/kurisunet/utils/debug.py
@@ -1,43 +1,87 @@
-from typing import Iterable, Literal
+from functools import wraps
+import random
 
-from kurisuinfo import CustomizedModuleName
-from torch import Tensor
-import torch.nn as nn
+import torch
 
 from ..utils.logger import get_logger
+from .module import get_module_name
 
 logger = get_logger("Utils")
 
 
-def __log_shape_hook(module, input, output):
+def log_shape_hook(module, input, output):
+    """Forward hook to log the shape of the input and output tensors of a module."""
+
     def get_shape(x):
-        if isinstance(x, Tensor):
+        if isinstance(x, torch.Tensor):
             return (
                 str(x.shape)
                 .replace("torch.Size", "")
                 .replace("([", "(")
                 .replace("])", ")")
             )
-        if isinstance(x, tuple):
+        if isinstance(x, (list, tuple)):
             return str([get_shape(i) for i in x]).replace("'", "")
         return str(x)
 
-    def get_name(module: nn.Module | CustomizedModuleName):
-        if isinstance(module, CustomizedModuleName):
-            return module.get_module_name()
-        if isinstance(module, nn.Module):
-            return module.__class__.__name__
-
     input_shape = get_shape(input[0] if len(input) == 1 else input)
     output_shape = get_shape(output)
-    module_name = get_name(module)
+    module_name = get_module_name(module)
     info = "Module: {:<20} Shape: {} -> {}"
-    logger.debug(info.format(module_name, input_shape, output_shape))
+    logger.info(info.format(module_name, input_shape, output_shape))
 
 
-def register_log_shape_hook(modules: Iterable[nn.Module] | Literal["all"] = "all"):
-    if modules == "all":
-        nn.modules.module.register_module_forward_hook(__log_shape_hook)
-        return
-    for module in modules:
-        module.register_forward_hook(__log_shape_hook)
+def reproduce(seed: int = 0, deterministic: bool = True):
+    """
+    WARN: This decorator has side effects on the entire process.
+    Decorator to set the random seed for reproducibility.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if deterministic:
+                torch.backends.cudnn.deterministic = True
+                torch.backends.cudnn.benchmark = False
+                torch.use_deterministic_algorithms(True)
+
+            random.seed(seed)
+            torch.manual_seed(seed)
+            torch.cuda.manual_seed_all(seed)
+            try:
+                import numpy as np
+            except ImportError:
+                logger.info("NumPy is not installed. Skipping NumPy seed setting.")
+            else:
+                np.random.seed(seed)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def is_close(a, b, rtol=1e-5, atol=1e-8) -> bool:
+    """compare two tensors or tensor containers with logging"""
+    if isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
+        if len(a) != len(b):
+            logger.info(f"Length mismatch: {len(a)} != {len(b)}")
+            return False
+        return all(is_close(x, y) for x, y in zip(a, b))
+    if isinstance(a, dict) and isinstance(b, dict):
+        if set(a.keys()) != set(b.keys()):
+            logger.info(f"Key mismatch: {set(a.keys())} != {set(b.keys())}")
+            return False
+        return all(is_close(a[k], b[k]) for k in a.keys())
+    if isinstance(a, torch.Tensor) and isinstance(b, torch.Tensor):
+        if a.shape != b.shape:
+            logger.info(f"Shape mismatch: {a.shape} != {b.shape}")
+            return False
+        if not a.isclose(b, rtol, atol).all():
+            logger.info(f"Value mismatch of two tensors")
+            logger.debug(f"Difference: {a - b}")
+            logger.info(f"Max difference: {torch.max(torch.abs(a - b))}")
+            return False
+        return True
+    logger.info(f"Type mismatch or unsupported comparison of {type(a)} and {type(b)}")
+    return False

--- a/src/kurisunet/utils/module.py
+++ b/src/kurisunet/utils/module.py
@@ -1,0 +1,48 @@
+from copy import deepcopy
+from typing import Callable
+
+from kurisuinfo import CustomizedModuleName
+import torch.nn as nn
+
+from ..net.module import PipelineModule
+from ..utils.logger import get_logger
+
+logger = get_logger("Utils")
+
+
+def get_module_name(module: nn.Module | CustomizedModuleName):
+    """Get the name of a module."""
+    if isinstance(module, CustomizedModuleName):
+        return module.get_module_name()
+    if isinstance(module, nn.Module):
+        return module.__class__.__name__
+
+
+def apply_module(
+    module: nn.Module,
+    func: Callable[[nn.Module], None],
+    filter: Callable[[nn.Module], bool] | None = None,
+    inplace: bool = False,
+) -> nn.Module:
+    """
+    Apply a function to all modules in a module.
+    Use `filter` to filter modules to apply the function.
+    """
+    if inplace:
+        logger.warning("The input module will be modified in-place")
+    else:
+        module = deepcopy(module)
+    for m in module.modules():
+        if filter is None or filter(m):
+            func(m)
+    return module
+
+
+def drop_module(module: nn.Module, inplace: bool = False) -> nn.Module:
+    """Drop all unused or set to dropped modules in PipelineModule."""
+    return apply_module(
+        module,
+        lambda m: m.drop(resort=True),  # type: ignore
+        filter=lambda m: isinstance(m, PipelineModule),
+        inplace=inplace,
+    )


### PR DESCRIPTION
This pull request includes several changes to improve the logging, reproducibility, and module handling in the `kurisunet` project. The most important changes include adding a decorator for setting random seeds, enhancing the logger configuration, and refactoring module utility functions.

### Improvements to logging:

* [`src/kurisunet/utils/debug.py`](diffhunk://#diff-4f87fbeb82e90ccf9f6d0f55f794bf6a2530985fdf41723fda9e9306a50e930fL1-R87): Changed the logging level from `debug` to `info` in the `log_shape_hook` function to provide more visibility into the module's input and output shapes.
* [`src/kurisunet/utils/logger.py`](diffhunk://#diff-b8d551007aca59051012a14fa963744ddd8226a44a0016ea62ef7d0a2d44d61eL22-R28): Added parameters for logging to a file and log file rotation in the `set_logger` function, allowing for more flexible logging configurations. [[1]](diffhunk://#diff-b8d551007aca59051012a14fa963744ddd8226a44a0016ea62ef7d0a2d44d61eL22-R28) [[2]](diffhunk://#diff-b8d551007aca59051012a14fa963744ddd8226a44a0016ea62ef7d0a2d44d61eL37-R59)

### Enhancements to reproducibility:

* [`src/kurisunet/utils/debug.py`](diffhunk://#diff-4f87fbeb82e90ccf9f6d0f55f794bf6a2530985fdf41723fda9e9306a50e930fL1-R87): Added a `reproduce` decorator to set random seeds for reproducibility, including handling for NumPy if installed.

### Refactoring module utilities:

* [`src/kurisunet/utils/module.py`](diffhunk://#diff-37280c316ca0e76d2f59e39a87579c2124d2880709837736442a4ef672e1bbf1R1-R48): Added functions `get_module_name`, `apply_module`, and `drop_module` to handle module operations more cleanly and modularly.
* [`src/kurisunet/utils/weights.py`](diffhunk://#diff-2e048773486b08dfb3c4c50278e6b3fb54488357b53e9070458d5d22c1625b26R18-R37): Refactored the `convert_state_dict` function to use a more descriptive conversion strategy and added docstrings for better code documentation. [[1]](diffhunk://#diff-2e048773486b08dfb3c4c50278e6b3fb54488357b53e9070458d5d22c1625b26R18-R37) [[2]](diffhunk://#diff-2e048773486b08dfb3c4c50278e6b3fb54488357b53e9070458d5d22c1625b26L45-L60)